### PR TITLE
add option to return index to detect_rpeaks()

### DIFF
--- a/R/ecg.R
+++ b/R/ecg.R
@@ -77,9 +77,9 @@ detect_rpeaks <- function(
   refractory <- sRate*(refractory/1000)
   x <- signal_conv
   for(i in c(2:(length(x)-1))){
-    if((x[i] > limit) &
-       (x[i] > x[i-1]) &
-       (x[i] > x[i+1]) &
+    if((x[i] > limit) &&
+       (x[i] > x[i-1]) &&
+       (x[i] > x[i+1]) &&
        ((i - peaks[length(peaks)]) > refractory)){
       peaks <- c(peaks,i)
     }

--- a/R/ecg.R
+++ b/R/ecg.R
@@ -9,7 +9,10 @@
 #' @param filter_order Butterworth bandpass filter order value.
 #' @param integration_window Convolution window size.
 #' @param refractory Minimal space between peaks in milliseconds.
-#' @return A numeric vector of detected R peaks, expressed in seconds from the start of the signal. This vector can be used in RHRV using `RHRV::LoadBeatVector()`.
+#' @param return_index If TRUE, the index for each R peak is returned instead of the timing. 
+#' @return A numeric vector of detected R peaks, expressed in seconds* from the start of the signal. This vector can be used in RHRV using `RHRV::LoadBeatVector()`.
+#' 
+#' *(or samples if return_index is TRUE)
 #' @export
 #' @examples
 #' path <- paste0(tempdir(),"rec_1.dat")
@@ -30,7 +33,8 @@ detect_rpeaks <- function(
   highcut = 15,
   filter_order = 1,
   integration_window = 15,
-  refractory = 200){
+  refractory = 200,
+  return_index = FALSE){
 
   nyquist_freq = 0.5 * sRate
   low = lowcut / nyquist_freq
@@ -81,7 +85,9 @@ detect_rpeaks <- function(
     }
   }
   peaks <- peaks[2:length(peaks)]
-
+  
+  if(return_index) return(peaks)
+  
   return(peaks/sRate)
 
 }

--- a/man/detect_rpeaks.Rd
+++ b/man/detect_rpeaks.Rd
@@ -4,8 +4,16 @@
 \alias{detect_rpeaks}
 \title{Detect R peaks in raw ECG signal.}
 \usage{
-detect_rpeaks(signal, sRate, lowcut = 0, highcut = 15,
-  filter_order = 1, integration_window = 15, refractory = 200)
+detect_rpeaks(
+  signal,
+  sRate,
+  lowcut = 0,
+  highcut = 15,
+  filter_order = 1,
+  integration_window = 15,
+  refractory = 200,
+  return_index = FALSE
+)
 }
 \arguments{
 \item{signal}{Numerical vector of ECG signal.}
@@ -21,9 +29,13 @@ detect_rpeaks(signal, sRate, lowcut = 0, highcut = 15,
 \item{integration_window}{Convolution window size.}
 
 \item{refractory}{Minimal space between peaks in milliseconds.}
+
+\item{return_index}{If `TRUE`, the index for each R peak is returned instead of the timing.}
 }
 \value{
-A numeric vector of detected R peaks, expressed in seconds from the start of the signal. This vector can be used in RHRV using `RHRV::LoadBeatVector()`.
+A numeric vector of detected R peaks, expressed in seconds* from the start of the signal. This vector can be used in RHRV using `RHRV::LoadBeatVector()`.
+
+*(or samples if `return_index` is `TRUE`)
 }
 \description{
 `detect_rpeaks` implements the first part of the Pan & Tompkins algorithms to detect R peaks from a raw ECG signal.


### PR DESCRIPTION
If an ECG signal is coded with a timestamp for each sample, it is useful to get the indexes of the detected R peaks, and then use those to get the timestamps for the R peaks.

In my case, I have a 500 Hz ecg, but if I calculate the mean diff between samples, the true sample rate is closer to 499.31 Hz. Even the smallest discrepancy in sample rate becomes really noticeably after a few minutes

(edit: Also, a small increase in performance can be achieved by evaluating peak conditions from left to right (using && instead of &). For long records, this can be a few seconds.

## Start of recording
![Screenshot from 2020-06-18 11-18-19](https://user-images.githubusercontent.com/11048760/85002693-82062a00-b155-11ea-8fb5-b4fc6d82e30e.png)

## After a few minutes
![Screenshot from 2020-06-18 11-18-08](https://user-images.githubusercontent.com/11048760/85002682-7fa3d000-b155-11ea-90d2-e1d3db6d3408.png)
 